### PR TITLE
Adding "deleteAllSessions" method

### DIFF
--- a/RestApi/Python/Modules/IxL_RestApi.py
+++ b/RestApi/Python/Modules/IxL_RestApi.py
@@ -16,6 +16,7 @@ import re
 import datetime
 import platform
 
+
 class IxLoadRestApiException(Exception):
     def __init__(self, msg=None):
         showErrorMsg = '\nIxLoadRestApiException error: {0}\n\n'.format(msg)
@@ -1241,7 +1242,12 @@ class Main():
 
     def deleteSessionId(self):
         response = self.delete(self.sessionIdUrl)
-        
+
+    def deleteAllSessions(self):
+        sessionUrl = '{}/api/{}/sessions'.format(self.httpHeader, self.apiVersion)
+        self.delete(sessionUrl)
+        print("All Ixia Sessions Deleted")
+
     def getMaximumInstances(self):
         response = self.get(self.sessionIdUrl+'/ixLoad/preferences')
         maxInstances = response.json()['maximumInstances']


### PR DESCRIPTION
We needed a way to cleanup all the running sessions without deleting them one by one, hence we introduce "deleteAllSessions" which wipes out all of them.

Thanks,
Karim